### PR TITLE
New article: eolchecker patch

### DIFF
--- a/_posts/2026-06-08-eolchecker-patch.md
+++ b/_posts/2026-06-08-eolchecker-patch.md
@@ -1,0 +1,35 @@
+---
+title: "eolchecker 0.1.1 released"
+tags:
+
+- eol
+- eos
+- Asset management
+- Utility
+- Community contribution
+- Open Source
+---
+
+I released eolchecker 0.1.1 today.
+
+This is a small maintenance release focused on dependency updates and package housekeeping. No new functionality has been added, and there are no changes to the user-facing command-line interface.
+
+The project itself remains intentionally simple. It gathers end-of-life information for software and hardware from public sources, stores the data locally, and allows quick queries without repeatedly browsing vendor websites or lifecycle portals.
+
+While the changes in this release are relatively minor, keeping dependencies current is still part of maintaining a tool. Small utilities have a tendency to sit untouched for long periods, which is exactly how outdated dependencies accumulate. This release is mostly about preventing that drift.
+
+For those unfamiliar with the project, eolchecker can be installed with:
+
+```bash
+pipx install eolchecker
+```
+
+Or you can just update:
+
+```bash
+pipx upgrade eolchecker
+```
+
+The source code is available on GitHub, and the package can be installed directly from PyPI.
+
+As before, software lifecycle information is obtained from the endoflife.date project, while hardware lifecycle information is collected from publicly available vendor support lifecycle pages.


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a new blog post announcing `eolchecker` 0.1.1, a maintenance release with dependency updates and no CLI changes. The post includes install/upgrade commands and a brief overview; no code changes beyond adding this article.

<sup>Written for commit b48a31e0d957f35f4d4e3578b9e9616ba4f9dd3a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zbalkan/zbalkan.github.io/pull/82?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

