### PR TITLE
Testing easter egg

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -113,7 +113,8 @@ footer:
 after_footer_scripts:
   - https://cdnjs.cloudflare.com/ajax/libs/mermaid/11.12.0/mermaid.min.js
   - https://cdn.jsdelivr.net/npm/mermaid@11.12.0/dist/mermaid.min.js
-  - assets/js/mermaid.js
+  - /assets/js/mermaid.js
+  - /assets/js/konami.js
 
 defaults:
   # _posts

--- a/_pages/game.md
+++ b/_pages/game.md
@@ -1,0 +1,11 @@
+---
+layout: splash
+permalink: /game/
+title: "Fatigue"
+sitemap: false
+---
+<meta name="robots" content="noindex, nofollow">
+<div style="text-align:center; margin-top: 6rem;">
+    <h1>Unlocked</h1>
+    <p>You found something that was not linked from anywhere.</p>
+</div>

--- a/assets/js/konami.js
+++ b/assets/js/konami.js
@@ -1,0 +1,60 @@
+(function () {
+  const sequence = [
+    "arrowup",
+    "arrowup",
+    "arrowdown",
+    "arrowdown",
+    "arrowleft",
+    "arrowright",
+    "arrowleft",
+    "arrowright",
+    "b",
+    "a"
+  ];
+
+  const timeoutMs = 1500;
+
+  let index = 0;
+  let timeoutId = null;
+
+  function resetSequence() {
+    index = 0;
+
+    if (timeoutId !== null) {
+      window.clearTimeout(timeoutId);
+      timeoutId = null;
+    }
+  }
+
+  function restartTimeout() {
+    if (timeoutId !== null) {
+      window.clearTimeout(timeoutId);
+    }
+
+    timeoutId = window.setTimeout(resetSequence, timeoutMs);
+  }
+
+  document.addEventListener("keydown", function (event) {
+    const key = event.key.toLowerCase();
+
+    if (key === sequence[index]) {
+      index += 1;
+
+      if (index === sequence.length) {
+        resetSequence();
+        window.location.assign("/game/");
+        return;
+      }
+
+      restartTimeout();
+      return;
+    }
+
+    resetSequence();
+
+    if (key === sequence[0]) {
+      index = 1;
+      restartTimeout();
+    }
+  });
+})();


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a Konami-code Easter egg that redirects to a hidden `/game/` page. Also switches footer script paths to absolute so assets load reliably.

- **New Features**
  - Konami-code listener (↑ ↑ ↓ ↓ ← → ← → B A) with 1.5s timeout per step; redirects to `/game/`.
  - Hidden `/game/` page using the splash layout with `noindex`.

- **Bug Fixes**
  - Use absolute footer script paths (`/assets/js/mermaid.js`, `/assets/js/konami.js`) to ensure loading from the site root.

<sup>Written for commit 8147ad1033592250463b26e0d812a91f6b931830. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zbalkan/zbalkan.github.io/pull/85?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

